### PR TITLE
feat: Button 컴포넌트 구현 & prettier 설정

### DIFF
--- a/picwithme/.prettierrc
+++ b/picwithme/.prettierrc
@@ -1,0 +1,11 @@
+{
+  "plugins": ["prettier-plugin-tailwindcss"],
+  "arrowParens": "always",
+  "semi": true,
+  "singleQuote": true,
+  "jsxSingleQuote": true,
+  "parser": "typescript",
+  "printWidth": 120,
+  "tabWidth": 2,
+  "trailingComma": "es5"
+}

--- a/picwithme/package-lock.json
+++ b/picwithme/package-lock.json
@@ -9,9 +9,11 @@
       "version": "0.0.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.1.10",
+        "clsx": "^2.1.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router": "^7.6.2",
+        "tailwind-merge": "^3.3.1",
         "tailwindcss": "^4.1.10"
       },
       "devDependencies": {
@@ -21,9 +23,12 @@
         "@types/react-dom": "^19.1.2",
         "@vitejs/plugin-react": "^4.4.1",
         "eslint": "^9.25.0",
+        "eslint-config-prettier": "^10.1.5",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.19",
         "globals": "^16.0.0",
+        "prettier": "^3.5.3",
+        "prettier-plugin-tailwindcss": "^0.6.13",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.30.1",
         "vite": "^6.3.5",
@@ -2423,6 +2428,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2725,6 +2739,22 @@
         "jiti": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.5",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.5.tgz",
+      "integrity": "sha512-zc1UmCpNltmVY34vuLRV61r1K27sWuX39E+uyUnY8xS2Bex88VV9cugG+UZbRSRGtGyFboj+D8JODyme1plMpw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
@@ -3819,6 +3849,101 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prettier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-tailwindcss": {
+      "version": "0.6.13",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.6.13.tgz",
+      "integrity": "sha512-uQ0asli1+ic8xrrSmIOaElDu0FacR4x69GynTh2oZjFY10JUt6EEumTQl5tB4fMeD6I1naKd+4rXQQ7esT2i1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "peerDependencies": {
+        "@ianvs/prettier-plugin-sort-imports": "*",
+        "@prettier/plugin-pug": "*",
+        "@shopify/prettier-plugin-liquid": "*",
+        "@trivago/prettier-plugin-sort-imports": "*",
+        "@zackad/prettier-plugin-twig": "*",
+        "prettier": "^3.0",
+        "prettier-plugin-astro": "*",
+        "prettier-plugin-css-order": "*",
+        "prettier-plugin-import-sort": "*",
+        "prettier-plugin-jsdoc": "*",
+        "prettier-plugin-marko": "*",
+        "prettier-plugin-multiline-arrays": "*",
+        "prettier-plugin-organize-attributes": "*",
+        "prettier-plugin-organize-imports": "*",
+        "prettier-plugin-sort-imports": "*",
+        "prettier-plugin-style-order": "*",
+        "prettier-plugin-svelte": "*"
+      },
+      "peerDependenciesMeta": {
+        "@ianvs/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "@prettier/plugin-pug": {
+          "optional": true
+        },
+        "@shopify/prettier-plugin-liquid": {
+          "optional": true
+        },
+        "@trivago/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "@zackad/prettier-plugin-twig": {
+          "optional": true
+        },
+        "prettier-plugin-astro": {
+          "optional": true
+        },
+        "prettier-plugin-css-order": {
+          "optional": true
+        },
+        "prettier-plugin-import-sort": {
+          "optional": true
+        },
+        "prettier-plugin-jsdoc": {
+          "optional": true
+        },
+        "prettier-plugin-marko": {
+          "optional": true
+        },
+        "prettier-plugin-multiline-arrays": {
+          "optional": true
+        },
+        "prettier-plugin-organize-attributes": {
+          "optional": true
+        },
+        "prettier-plugin-organize-imports": {
+          "optional": true
+        },
+        "prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "prettier-plugin-style-order": {
+          "optional": true
+        },
+        "prettier-plugin-svelte": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -4090,6 +4215,16 @@
       "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.3.1.tgz",
+      "integrity": "sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
     },
     "node_modules/tailwindcss": {
       "version": "4.1.10",

--- a/picwithme/package.json
+++ b/picwithme/package.json
@@ -11,9 +11,11 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.10",
+    "clsx": "^2.1.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.6.2",
+    "tailwind-merge": "^3.3.1",
     "tailwindcss": "^4.1.10"
   },
   "devDependencies": {
@@ -23,9 +25,12 @@
     "@types/react-dom": "^19.1.2",
     "@vitejs/plugin-react": "^4.4.1",
     "eslint": "^9.25.0",
+    "eslint-config-prettier": "^10.1.5",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^16.0.0",
+    "prettier": "^3.5.3",
+    "prettier-plugin-tailwindcss": "^0.6.13",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.30.1",
     "vite": "^6.3.5",

--- a/picwithme/src/App.tsx
+++ b/picwithme/src/App.tsx
@@ -1,10 +1,11 @@
-import { BrowserRouter, Route, Routes } from "react-router";
-import "./App.css";
-import Login from "@page/auth/Login";
-import AuthLayout from "@components/Layouts/AuthLayout";
-import FindId from "@page/auth/FindId";
-import Error404 from "@page/error/404";
-import FindPw from "@page/auth/FindPw";
+import { BrowserRouter, Route, Routes } from 'react-router';
+import './App.css';
+import Login from '@page/auth/Login';
+import AuthLayout from '@components/Layouts/AuthLayout';
+import FindId from '@page/auth/FindId';
+import Error404 from '@page/error/404';
+import FindPw from '@page/auth/FindPw';
+import Album from '@/pages/album';
 
 function App() {
   return (
@@ -12,10 +13,11 @@ function App() {
       <Routes>
         <Route element={<AuthLayout />}>
           <Route index element={<Login />} />
-          <Route path="/findId" element={<FindId />} />
-          <Route path="/findPw" element={<FindPw />} />
+          <Route path='/findId' element={<FindId />} />
+          <Route path='/findPw' element={<FindPw />} />
         </Route>
-        <Route path="*" element={<Error404 />} />
+        <Route path='/album' element={<Album />} />
+        <Route path='*' element={<Error404 />} />
       </Routes>
     </BrowserRouter>
   );

--- a/picwithme/src/components/ui/Button.tsx
+++ b/picwithme/src/components/ui/Button.tsx
@@ -1,0 +1,28 @@
+import { cn } from '@/utils/cn';
+
+interface ButtonProps {
+  onClick: () => void;
+  children: React.ReactNode;
+  variant?: 'primary' | 'secondary' | 'danger' | 'disabled';
+  className?: string;
+}
+
+const variantStyle: Record<string, string> = {
+  primary: 'bg-primary-default text-white hover:bg-primary-default/90 transition-colors',
+  secondary: 'border border-primary-default hover:bg-primary-lighter text-primary-default ',
+  danger: 'bg-danger text-white hover:bg-danger/90 transition-colors',
+  disabled: 'bg-primary-lighter text-gray-200 cursor-not-allowed',
+} as const;
+
+const Button: React.FC<ButtonProps> = ({ onClick, children, variant = 'primary', className }) => {
+  return (
+    <button
+      onClick={onClick}
+      className={cn('text-body2 w-full cursor-pointer rounded-lg p-3 font-semibold', variantStyle[variant], className)}
+    >
+      {children}
+    </button>
+  );
+};
+
+export default Button;

--- a/picwithme/src/pages/album/index.tsx
+++ b/picwithme/src/pages/album/index.tsx
@@ -1,0 +1,21 @@
+import Button from '@/components/ui/Button';
+
+const Album: React.FC = () => {
+  return (
+    <div className='flex flex-col items-center justify-center gap-4 p-10'>
+      <h1>Album Page</h1>
+      <p>This is the album page content.</p>
+      <Button onClick={() => {}}>로그인</Button>
+      <Button variant='secondary' onClick={() => {}}>
+        로그아웃
+      </Button>
+      <Button variant='danger' onClick={() => {}}>
+        삭제
+      </Button>
+      <Button variant='disabled' onClick={() => {}}>
+        비활성화
+      </Button>
+    </div>
+  );
+};
+export default Album;

--- a/picwithme/src/utils/cn.ts
+++ b/picwithme/src/utils/cn.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
# Done
- Button Component 구현 완료
  - 해당 과정에서 `clsx`, `tailwind-merge` 의존성을 추가하였고, utils 폴더 내 `cn` 함수를 정의하였습니다.
  - `clsx`: 조건부 클래스 처리 (&&, ?:)
  - `tailwind-merge`: 중복된 Tailwind CSS 클래스를 제거하고, 마지막에 선언된 클래스를 우선시하여 병합
- prettier 설정
  - [공식 문서](https://tailwindcss.com/blog/automatic-class-sorting-with-prettier)에 따라 `prettier-plugin-tailwindcss`, `prettier` 의존성 추가
  - prettier과 eslint 사이의 충돌을 막기 위해 `eslint-config-prettier` 설치